### PR TITLE
Add core-domain workflow orchestration library

### DIFF
--- a/libs/core-domain/README.md
+++ b/libs/core-domain/README.md
@@ -1,0 +1,46 @@
+# @plutus/core-domain
+
+Enterprise workflow primitives shared between the portal Next.js app and the
+orchestrator service. The package provides:
+
+- `createWorkflowDefinition` – normalizes workflow descriptors, performs safety
+  validation, and precomputes helpful aggregates such as ordered step IDs and
+  total SLA duration.
+- `initializeWorkflow` / `advanceWorkflow` – a deterministic state machine that
+  guards transitions, tracks audit history, and automatically routes failure
+  branches.
+- `buildWorkflowTimeline` – materializes presentation-ready timeline entries
+  with status labels and timestamps for customer support tooling.
+- `testing/*` fixtures – strongly typed, reusable seeds for loan-origination
+  flows used by both portal and orchestrator test suites.
+
+## Usage
+
+```ts
+import {
+  createWorkflowDefinition,
+  initializeWorkflow,
+  advanceWorkflow,
+  buildWorkflowTimeline,
+} from '@plutus/core-domain';
+
+const definition = createWorkflowDefinition({...});
+const runtime = initializeWorkflow(definition, {
+  tenantId: 'tenant-a',
+  applicationId: 'abc123',
+  correlationId: 'req-1',
+});
+const progressed = advanceWorkflow(definition, runtime, {
+  type: 'STEP_COMPLETED',
+  stepId: 'collect-intake',
+  occurredAt: new Date(),
+});
+const timeline = buildWorkflowTimeline(definition, progressed);
+```
+
+## Developer workflow
+
+- `pnpm nx build core-domain` – compile the TypeScript sources to
+  `dist/libs/core-domain`.
+- `pnpm nx test core-domain` – execute Jest specs covering nominal, branching,
+  and failure scenarios for the state machine and timeline helpers.

--- a/libs/core-domain/jest.config.ts
+++ b/libs/core-domain/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+import rootConfig from '../../jest.config';
+
+const config: Config = {
+  ...rootConfig,
+  displayName: 'core-domain',
+  rootDir: __dirname,
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/*.spec.ts'],
+  moduleNameMapper: {
+    ...(rootConfig.moduleNameMapper ?? {}),
+    '^@plutus/core-domain$': '<rootDir>/src/index.ts',
+    '^@plutus/core-domain/(.*)$': '<rootDir>/src/$1',
+  },
+  coverageDirectory: '../../coverage/libs/core-domain',
+};
+
+export default config;

--- a/libs/core-domain/package.json
+++ b/libs/core-domain/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@plutus/core-domain",
+  "version": "0.0.1",
+  "private": true,
+  "type": "commonjs",
+  "main": "./src/index.js",
+  "types": "./src/index.d.ts",
+  "dependencies": {
+    "tslib": "^2.3.0"
+  }
+}

--- a/libs/core-domain/project.json
+++ b/libs/core-domain/project.json
@@ -1,0 +1,27 @@
+{
+  "name": "core-domain",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/core-domain/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/libs/core-domain",
+        "main": "libs/core-domain/src/index.ts",
+        "tsConfig": "libs/core-domain/tsconfig.lib.json",
+        "assets": ["libs/core-domain/*.md"]
+      }
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/libs/core-domain"],
+      "options": {
+        "jestConfig": "libs/core-domain/jest.config.ts",
+        "passWithNoTests": false
+      }
+    }
+  }
+}

--- a/libs/core-domain/src/errors.ts
+++ b/libs/core-domain/src/errors.ts
@@ -1,0 +1,23 @@
+/**
+ * Error thrown when a workflow definition fails validation or contains
+ * inconsistencies that would break downstream orchestrations.
+ */
+export class WorkflowDefinitionError extends Error {
+  public override readonly name = 'WorkflowDefinitionError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}
+
+/**
+ * Error thrown when a workflow state transition request is invalid for the
+ * current runtime state.
+ */
+export class WorkflowStateTransitionError extends Error {
+  public override readonly name = 'WorkflowStateTransitionError';
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/libs/core-domain/src/index.ts
+++ b/libs/core-domain/src/index.ts
@@ -1,0 +1,26 @@
+export {
+  createWorkflowDefinition,
+  type WorkflowDefinition,
+  type WorkflowDefinitionInput,
+  type WorkflowStepDefinition,
+  type WorkflowStepInput,
+} from './workflow-definition';
+export {
+  initializeWorkflow,
+  advanceWorkflow,
+  type WorkflowTransitionEvent,
+} from './state-machine';
+export {
+  type WorkflowContext,
+  type WorkflowEvent,
+  type WorkflowState,
+  type InitializeWorkflowOptions,
+} from './workflow-state';
+export {
+  buildWorkflowTimeline,
+  type WorkflowTimelineEntry,
+  type WorkflowTimelineSnapshot,
+  type WorkflowStepStatus,
+} from './timeline';
+export { WorkflowDefinitionError, WorkflowStateTransitionError } from './errors';
+export * as testing from './testing';

--- a/libs/core-domain/src/state-machine.spec.ts
+++ b/libs/core-domain/src/state-machine.spec.ts
@@ -1,0 +1,94 @@
+import { advanceWorkflow, initializeWorkflow } from './state-machine';
+import { WorkflowStateTransitionError } from './errors';
+import { defaultLoanWorkflowContext, buildLoanOriginationDefinition } from './testing';
+
+describe('workflow state machine', () => {
+  const definition = buildLoanOriginationDefinition();
+  const baseTimestamp = new Date('2024-01-01T00:00:00.000Z');
+
+  it('initializes with the entry step active and history seeded', () => {
+    const state = initializeWorkflow(definition, defaultLoanWorkflowContext, {
+      timestamp: baseTimestamp,
+    });
+
+    expect(state.activeStepId).toEqual('collect-intake');
+    expect(state.completedStepIds).toEqual([]);
+    expect(state.failedStepIds).toEqual([]);
+    expect(state.history).toHaveLength(2);
+    expect(state.history[0]).toMatchObject({
+      type: 'WORKFLOW_INITIALIZED',
+      stepId: 'collect-intake',
+      occurredAt: baseTimestamp,
+    });
+    expect(state.history[1]).toMatchObject({
+      type: 'STEP_ACTIVATED',
+      stepId: 'collect-intake',
+    });
+  });
+
+  it('advances sequential happy path transitions', () => {
+    const state = initializeWorkflow(definition, defaultLoanWorkflowContext, {
+      timestamp: baseTimestamp,
+    });
+
+    const afterIntake = advanceWorkflow(definition, state, {
+      type: 'STEP_COMPLETED',
+      stepId: 'collect-intake',
+      occurredAt: new Date('2024-01-01T00:15:00.000Z'),
+    });
+
+    expect(afterIntake.completedStepIds).toEqual(['collect-intake']);
+    expect(afterIntake.activeStepId).toEqual('kyc-screening');
+
+    const afterKyc = advanceWorkflow(definition, afterIntake, {
+      type: 'STEP_COMPLETED',
+      stepId: 'kyc-screening',
+      occurredAt: new Date('2024-01-01T00:20:00.000Z'),
+    });
+
+    expect(afterKyc.completedStepIds).toEqual(['collect-intake', 'kyc-screening']);
+    expect(afterKyc.activeStepId).toEqual('credit-decision');
+  });
+
+  it('routes to manual review when screening fails', () => {
+    const state = initializeWorkflow(definition, defaultLoanWorkflowContext, {
+      timestamp: baseTimestamp,
+    });
+
+    const afterIntake = advanceWorkflow(definition, state, {
+      type: 'STEP_COMPLETED',
+      stepId: 'collect-intake',
+      occurredAt: new Date('2024-01-01T00:15:00.000Z'),
+    });
+
+    const afterFailure = advanceWorkflow(definition, afterIntake, {
+      type: 'STEP_FAILED',
+      stepId: 'kyc-screening',
+      occurredAt: new Date('2024-01-01T00:20:00.000Z'),
+      reason: 'Watchlist hit',
+    });
+
+    expect(afterFailure.failedStepIds).toEqual(['kyc-screening']);
+    expect(afterFailure.activeStepId).toEqual('manual-review');
+    expect(afterFailure.history).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'STEP_FAILED', stepId: 'kyc-screening' }),
+        expect.objectContaining({ type: 'STEP_ACTIVATED', stepId: 'manual-review' }),
+      ]),
+    );
+  });
+
+  it('rejects out-of-order completions', () => {
+    const state = initializeWorkflow(definition, defaultLoanWorkflowContext, {
+      timestamp: baseTimestamp,
+    });
+
+    expect(() =>
+      advanceWorkflow(definition, state, {
+        type: 'STEP_COMPLETED',
+        stepId: 'credit-decision',
+        occurredAt: new Date('2024-01-01T00:05:00.000Z'),
+      }),
+    ).toThrow(WorkflowStateTransitionError);
+  });
+});

--- a/libs/core-domain/src/state-machine.ts
+++ b/libs/core-domain/src/state-machine.ts
@@ -1,0 +1,242 @@
+import { WorkflowStateTransitionError } from './errors';
+import type {
+  InitializeWorkflowOptions,
+  WorkflowContext,
+  WorkflowEvent,
+  WorkflowState,
+} from './workflow-state';
+import { createEmptyState } from './workflow-state';
+import type { WorkflowDefinition, WorkflowStepDefinition } from './workflow-definition';
+
+/**
+ * Events accepted by {@link advanceWorkflow} to mutate the runtime state.
+ */
+export type WorkflowTransitionEvent =
+  | {
+      readonly type: 'STEP_COMPLETED';
+      readonly stepId: string;
+      readonly occurredAt: Date;
+      readonly notes?: string;
+    }
+  | {
+      readonly type: 'STEP_FAILED';
+      readonly stepId: string;
+      readonly occurredAt: Date;
+      readonly reason?: string;
+      readonly retryable?: boolean;
+    };
+
+const toDate = (value: Date | undefined): Date => (value instanceof Date ? value : new Date());
+
+const areDependenciesSatisfied = (
+  definition: WorkflowDefinition,
+  step: WorkflowStepDefinition,
+  completed: ReadonlySet<string>,
+  failed: ReadonlySet<string>,
+): boolean =>
+  step.dependencies.every((dependency) => completed.has(dependency) || failed.has(dependency));
+
+const chooseNextActiveStep = (
+  definition: WorkflowDefinition,
+  completed: ReadonlySet<string>,
+  failed: ReadonlySet<string>,
+  preferredStepId?: string | null,
+): string | null => {
+  if (preferredStepId) {
+    const preferred = definition.steps[preferredStepId];
+    if (preferred) {
+      const isAvailable =
+        !completed.has(preferredStepId) &&
+        !failed.has(preferredStepId) &&
+        areDependenciesSatisfied(definition, preferred, completed, failed);
+      if (isAvailable) {
+        return preferredStepId;
+      }
+    }
+  }
+
+  return (
+    definition.orderedStepIds.find((stepId) => {
+      if (completed.has(stepId) || failed.has(stepId)) {
+        return false;
+      }
+      const step = definition.steps[stepId];
+      return areDependenciesSatisfied(definition, step, completed, failed);
+    }) ?? null
+  );
+};
+
+const appendEvent = (history: WorkflowEvent[], event: WorkflowEvent): WorkflowEvent[] => [
+  ...history,
+  event,
+];
+
+/**
+ * Initialize a workflow state for an application using the provided definition
+ * and context. The returned state is immutable and can be safely shared across
+ * orchestrator services.
+ */
+export const initializeWorkflow = (
+  definition: WorkflowDefinition,
+  context: WorkflowContext,
+  options: InitializeWorkflowOptions = {},
+): WorkflowState => {
+  const timestamp = toDate(options.timestamp ?? new Date());
+  const baseState = createEmptyState(definition, context, timestamp, options.metadata);
+
+  const entryStep = definition.steps[definition.entryStepId];
+  if (!entryStep) {
+    throw new WorkflowStateTransitionError(
+      `Workflow definition "${definition.id}" is missing its configured entry step.`,
+    );
+  }
+
+  if (entryStep.dependencies.length > 0) {
+    throw new WorkflowStateTransitionError(
+      `Entry step "${entryStep.id}" cannot declare dependencies; adjust the workflow definition.`,
+    );
+  }
+
+  const history: WorkflowEvent[] = [
+    {
+      type: 'WORKFLOW_INITIALIZED',
+      occurredAt: timestamp,
+      stepId: entryStep.id,
+    },
+    {
+      type: 'STEP_ACTIVATED',
+      occurredAt: timestamp,
+      stepId: entryStep.id,
+      reason: 'initial-entry',
+    },
+  ];
+
+  return {
+    ...baseState,
+    activeStepId: entryStep.id,
+    history,
+  };
+};
+
+const assertStepIsEligible = (
+  definition: WorkflowDefinition,
+  step: WorkflowStepDefinition,
+  completed: ReadonlySet<string>,
+  failed: ReadonlySet<string>,
+  activeStepId: string | null,
+): void => {
+  if (completed.has(step.id)) {
+    throw new WorkflowStateTransitionError(
+      `Step "${step.id}" has already completed; duplicate completion events are not allowed.`,
+    );
+  }
+
+  if (failed.has(step.id)) {
+    throw new WorkflowStateTransitionError(
+      `Step "${step.id}" has already failed; resolve the failure before re-emitting events.`,
+    );
+  }
+
+  const dependenciesSatisfied = areDependenciesSatisfied(definition, step, completed, failed);
+  if (!dependenciesSatisfied) {
+    throw new WorkflowStateTransitionError(
+      `Step "${step.id}" cannot transition because upstream dependencies are incomplete.`,
+    );
+  }
+
+  if (activeStepId && activeStepId !== step.id) {
+    throw new WorkflowStateTransitionError(
+      `Step "${step.id}" is not the currently active step (${activeStepId}); defer the event.`,
+    );
+  }
+};
+
+/**
+ * Advance a workflow state by applying the provided transition events in order.
+ * The function returns a fresh state object leaving the original untouched to
+ * encourage pure functional programming patterns.
+ */
+export const advanceWorkflow = (
+  definition: WorkflowDefinition,
+  currentState: WorkflowState,
+  ...events: readonly WorkflowTransitionEvent[]
+): WorkflowState => {
+  if (events.length === 0) {
+    return currentState;
+  }
+
+  const completed = new Set(currentState.completedStepIds);
+  const failed = new Set(currentState.failedStepIds);
+  let history = [...currentState.history];
+  let activeStepId = currentState.activeStepId;
+  let lastTimestamp = currentState.updatedAt;
+
+  for (const event of events) {
+    const timestamp = toDate(event.occurredAt);
+    if (timestamp > lastTimestamp) {
+      lastTimestamp = timestamp;
+    }
+
+    const step = definition.steps[event.stepId];
+    if (!step) {
+      throw new WorkflowStateTransitionError(
+        `Unknown step "${event.stepId}" referenced by transition event ${event.type}.`,
+      );
+    }
+
+    assertStepIsEligible(definition, step, completed, failed, activeStepId);
+
+    switch (event.type) {
+      case 'STEP_COMPLETED': {
+        completed.add(step.id);
+        activeStepId = activeStepId === step.id ? null : activeStepId;
+        history = appendEvent(history, event);
+        const nextStepId = chooseNextActiveStep(definition, completed, failed, step.onSuccess);
+        if (nextStepId) {
+          history = appendEvent(history, {
+            type: 'STEP_ACTIVATED',
+            stepId: nextStepId,
+            occurredAt: timestamp,
+            reason: 'dependency-satisfied',
+          });
+          activeStepId = nextStepId;
+        }
+        break;
+      }
+      case 'STEP_FAILED': {
+        failed.add(step.id);
+        activeStepId = activeStepId === step.id ? null : activeStepId;
+        history = appendEvent(history, event);
+        const nextStepId = chooseNextActiveStep(definition, completed, failed, step.onFailure);
+        if (nextStepId) {
+          history = appendEvent(history, {
+            type: 'STEP_ACTIVATED',
+            stepId: nextStepId,
+            occurredAt: timestamp,
+            reason: 'dependency-satisfied',
+          });
+          activeStepId = nextStepId;
+        }
+        break;
+      }
+      default: {
+        const exhaustiveCheck: never = event;
+        throw new WorkflowStateTransitionError(
+          `Unsupported workflow transition event ${(exhaustiveCheck as WorkflowTransitionEvent).type}.`,
+        );
+      }
+    }
+  }
+
+  const orderedCompleted = definition.orderedStepIds.filter((id) => completed.has(id));
+  const orderedFailed = definition.orderedStepIds.filter((id) => failed.has(id));
+
+  return {
+    ...currentState,
+    activeStepId,
+    completedStepIds: orderedCompleted,
+    failedStepIds: orderedFailed,
+    history,
+    updatedAt: lastTimestamp,
+  };
+};

--- a/libs/core-domain/src/testing/index.ts
+++ b/libs/core-domain/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './loan-origination.fixture';

--- a/libs/core-domain/src/testing/loan-origination.fixture.ts
+++ b/libs/core-domain/src/testing/loan-origination.fixture.ts
@@ -1,0 +1,151 @@
+import { buildWorkflowTimeline } from '../timeline';
+import { advanceWorkflow, initializeWorkflow } from '../state-machine';
+import type { WorkflowTransitionEvent } from '../state-machine';
+import type {
+  WorkflowContext,
+  WorkflowState,
+  InitializeWorkflowOptions,
+} from '../workflow-state';
+import {
+  type WorkflowDefinition,
+  type WorkflowDefinitionInput,
+  createWorkflowDefinition,
+} from '../workflow-definition';
+
+/**
+ * Canonical workflow definition used by both the portal and orchestrator tests
+ * to keep fixtures aligned across surfaces.
+ */
+export const loanOriginationWorkflowDefinitionInput: WorkflowDefinitionInput = {
+  id: 'loan-orchestration',
+  name: 'Loan Origination Flow',
+  version: '2024.10.01',
+  entryStepId: 'collect-intake',
+  steps: [
+    {
+      id: 'collect-intake',
+      stage: 'intake',
+      name: 'Collect borrower intake package',
+      description: 'Portal intake forms, document capture, borrower attestations.',
+      dependencies: [],
+      onSuccess: 'kyc-screening',
+      expectedDurationSeconds: 900,
+    },
+    {
+      id: 'kyc-screening',
+      stage: 'verification',
+      name: 'KYC & AML screening',
+      description: 'Identity, sanctions, PEP, and watchlist checks.',
+      dependencies: ['collect-intake'],
+      onSuccess: 'credit-decision',
+      onFailure: 'manual-review',
+      expectedDurationSeconds: 300,
+    },
+    {
+      id: 'credit-decision',
+      stage: 'decision',
+      name: 'Decisioning & pricing',
+      description: 'Policy DAG execution, adverse action reasoning, pricing.',
+      dependencies: ['kyc-screening'],
+      onSuccess: 'funding',
+      onFailure: 'manual-review',
+      expectedDurationSeconds: 120,
+    },
+    {
+      id: 'funding',
+      stage: 'funding',
+      name: 'Funding & GL reconciliation',
+      description: 'Wire orchestration, lien filings, general ledger postings.',
+      dependencies: ['credit-decision'],
+      onSuccess: null,
+      expectedDurationSeconds: 600,
+    },
+    {
+      id: 'manual-review',
+      stage: 'decision',
+      name: 'Operational manual review',
+      description: 'Risk officer override path for escalated applications.',
+      dependencies: ['kyc-screening'],
+      onSuccess: 'funding',
+      expectedDurationSeconds: 3600,
+    },
+  ],
+};
+
+/** Default workflow context used across fixtures. */
+export const defaultLoanWorkflowContext: WorkflowContext = {
+  applicationId: 'demo-app',
+  tenantId: 'demo-tenant',
+  correlationId: 'demo-correlation',
+  metadata: { seeded: 'true' },
+};
+
+/**
+ * Convenience helper for generating the immutable workflow definition from the
+ * shared {@link loanOriginationWorkflowDefinitionInput} descriptor.
+ */
+export const buildLoanOriginationDefinition = (): WorkflowDefinition =>
+  createWorkflowDefinition(loanOriginationWorkflowDefinitionInput);
+
+/**
+ * Options for {@link seedLoanOriginationWorkflow} allowing scenario specific
+ * overrides.
+ */
+export interface LoanWorkflowSeedOptions {
+  readonly context?: Partial<WorkflowContext>;
+  readonly timestamp?: Date;
+  readonly initializeOptions?: Partial<InitializeWorkflowOptions>;
+  readonly events?: readonly WorkflowTransitionEvent[];
+}
+
+/**
+ * Seed the loan origination workflow, applying any provided transition events
+ * to produce a deterministic runtime state suitable for tests.
+ */
+export const seedLoanOriginationWorkflow = (
+  options: LoanWorkflowSeedOptions = {},
+): {
+  readonly definition: WorkflowDefinition;
+  readonly state: WorkflowState;
+} => {
+  const definition = buildLoanOriginationDefinition();
+  const timestamp = options.timestamp ?? new Date('2024-01-01T00:00:00.000Z');
+
+  const context: WorkflowContext = {
+    ...defaultLoanWorkflowContext,
+    ...options.context,
+    metadata: {
+      ...defaultLoanWorkflowContext.metadata,
+      ...(options.context?.metadata ?? {}),
+    },
+  };
+
+  const initialState = initializeWorkflow(
+    definition,
+    context,
+    {
+      timestamp,
+      ...(options.initializeOptions ?? {}),
+    },
+  );
+
+  const state = options.events?.length
+    ? advanceWorkflow(definition, initialState, ...options.events)
+    : initialState;
+
+  return {
+    definition,
+    state,
+  };
+};
+
+/**
+ * Generate a timeline snapshot for UI assertions without forcing callers to
+ * duplicate derivation logic.
+ */
+export const seedLoanOriginationTimeline = (
+  options: LoanWorkflowSeedOptions = {},
+) => {
+  const { definition, state } = seedLoanOriginationWorkflow(options);
+  return buildWorkflowTimeline(definition, state);
+};

--- a/libs/core-domain/src/timeline.spec.ts
+++ b/libs/core-domain/src/timeline.spec.ts
@@ -1,0 +1,77 @@
+import { buildWorkflowTimeline } from './timeline';
+import { initializeWorkflow } from './state-machine';
+import {
+  buildLoanOriginationDefinition,
+  defaultLoanWorkflowContext,
+  seedLoanOriginationWorkflow,
+} from './testing';
+
+describe('workflow timeline utilities', () => {
+  const definition = buildLoanOriginationDefinition();
+  const baseTimestamp = new Date('2024-01-01T00:00:00.000Z');
+
+  it('marks the entry step as active for a fresh workflow', () => {
+    const state = initializeWorkflow(definition, defaultLoanWorkflowContext, {
+      timestamp: baseTimestamp,
+    });
+
+    const timeline = buildWorkflowTimeline(definition, state);
+    const intakeEntry = timeline.entries.find((entry) => entry.stepId === 'collect-intake');
+    const kycEntry = timeline.entries.find((entry) => entry.stepId === 'kyc-screening');
+
+    expect(intakeEntry?.status).toBe('Active');
+    expect(intakeEntry?.startedAt).toEqual(baseTimestamp);
+    expect(intakeEntry?.completedAt).toBeUndefined();
+    expect(kycEntry?.status).toBe('Pending');
+  });
+
+  it('tracks nominal progression with cumulative SLA calculations', () => {
+    const seeded = seedLoanOriginationWorkflow({
+      events: [
+        {
+          type: 'STEP_COMPLETED',
+          stepId: 'collect-intake',
+          occurredAt: new Date('2024-01-01T00:15:00.000Z'),
+        },
+        {
+          type: 'STEP_COMPLETED',
+          stepId: 'kyc-screening',
+          occurredAt: new Date('2024-01-01T00:20:00.000Z'),
+        },
+      ],
+    });
+
+    const timeline = buildWorkflowTimeline(definition, seeded.state);
+    const creditDecision = timeline.entries.find((entry) => entry.stepId === 'credit-decision');
+
+    expect(timeline.completedExpectedDurationSeconds).toBe(900 + 300);
+    expect(creditDecision?.status).toBe('Active');
+  });
+
+  it('labels downstream branches when failures occur', () => {
+    const seeded = seedLoanOriginationWorkflow({
+      events: [
+        {
+          type: 'STEP_COMPLETED',
+          stepId: 'collect-intake',
+          occurredAt: new Date('2024-01-01T00:05:00.000Z'),
+        },
+        {
+          type: 'STEP_FAILED',
+          stepId: 'kyc-screening',
+          occurredAt: new Date('2024-01-01T00:10:00.000Z'),
+          reason: 'Document mismatch',
+        },
+      ],
+    });
+
+    const timeline = buildWorkflowTimeline(definition, seeded.state);
+    const manualReview = timeline.entries.find((entry) => entry.stepId === 'manual-review');
+    const kycEntry = timeline.entries.find((entry) => entry.stepId === 'kyc-screening');
+
+    expect(kycEntry?.status).toBe('Failed');
+    expect(kycEntry?.failedAt).toEqual(new Date('2024-01-01T00:10:00.000Z'));
+    expect(manualReview?.status).toBe('Active');
+    expect(manualReview?.startedAt).toEqual(new Date('2024-01-01T00:10:00.000Z'));
+  });
+});

--- a/libs/core-domain/src/timeline.ts
+++ b/libs/core-domain/src/timeline.ts
@@ -1,0 +1,109 @@
+import type { WorkflowDefinition, WorkflowStepDefinition } from './workflow-definition';
+import type { WorkflowEvent, WorkflowState } from './workflow-state';
+
+/** Enumerates the statuses surfaced to UI clients. */
+export type WorkflowStepStatus = 'Pending' | 'Active' | 'Completed' | 'Failed';
+
+/**
+ * Timeline entry representing a step enriched with runtime state and analytics
+ * friendly metadata for dashboards or customer support tooling.
+ */
+export interface WorkflowTimelineEntry {
+  readonly stepId: string;
+  readonly name: string;
+  readonly description: string;
+  readonly stage: string;
+  readonly order: number;
+  readonly status: WorkflowStepStatus;
+  readonly expectedDurationSeconds: number;
+  readonly startedAt?: Date;
+  readonly completedAt?: Date;
+  readonly failedAt?: Date;
+  readonly metadata?: Record<string, unknown>;
+}
+
+/** Snapshot structure returned by {@link buildWorkflowTimeline}. */
+export interface WorkflowTimelineSnapshot {
+  readonly definitionId: string;
+  readonly version: string;
+  readonly generatedAt: Date;
+  readonly entries: readonly WorkflowTimelineEntry[];
+  readonly totalExpectedDurationSeconds: number;
+  readonly completedExpectedDurationSeconds: number;
+}
+
+const findEvent = <T extends WorkflowEvent['type']>(
+  history: readonly WorkflowEvent[],
+  stepId: string,
+  type: T,
+): WorkflowEvent & { type: T } | undefined =>
+  history.find(
+    (event): event is WorkflowEvent & { type: T } =>
+      event.stepId === stepId && event.type === type,
+  );
+
+const computeStatus = (
+  state: WorkflowState,
+  step: WorkflowStepDefinition,
+): WorkflowStepStatus => {
+  if (state.failedStepIds.includes(step.id)) {
+    return 'Failed';
+  }
+  if (state.completedStepIds.includes(step.id)) {
+    return 'Completed';
+  }
+  if (state.activeStepId === step.id) {
+    return 'Active';
+  }
+  return 'Pending';
+};
+
+const deriveEntry = (
+  state: WorkflowState,
+  step: WorkflowStepDefinition,
+): WorkflowTimelineEntry => {
+  const startedAt = findEvent(state.history, step.id, 'STEP_ACTIVATED')?.occurredAt;
+  const completedAt = findEvent(state.history, step.id, 'STEP_COMPLETED')?.occurredAt;
+  const failedAt = findEvent(state.history, step.id, 'STEP_FAILED')?.occurredAt;
+
+  return {
+    stepId: step.id,
+    name: step.name,
+    description: step.description,
+    stage: step.stage,
+    order: step.order,
+    status: computeStatus(state, step),
+    expectedDurationSeconds: step.expectedDurationSeconds ?? 0,
+    startedAt,
+    completedAt,
+    failedAt,
+    metadata: step.metadata,
+  };
+};
+
+/**
+ * Assemble a timeline snapshot for analytics, UI rendering, or status
+ * webhooks. The structure is optimized for read-heavy workloads to minimize
+ * repeated derivation logic in callers.
+ */
+export const buildWorkflowTimeline = (
+  definition: WorkflowDefinition,
+  state: WorkflowState,
+): WorkflowTimelineSnapshot => {
+  const entries = definition.orderedStepIds.map((stepId) =>
+    deriveEntry(state, definition.steps[stepId]),
+  );
+
+  const completedExpectedDurationSeconds = entries
+    .filter((entry) => entry.status === 'Completed')
+    .reduce((total, entry) => total + entry.expectedDurationSeconds, 0);
+
+  return {
+    definitionId: definition.id,
+    version: definition.version,
+    generatedAt: new Date(),
+    entries,
+    totalExpectedDurationSeconds: definition.totalExpectedDurationSeconds,
+    completedExpectedDurationSeconds,
+  };
+};

--- a/libs/core-domain/src/workflow-definition.ts
+++ b/libs/core-domain/src/workflow-definition.ts
@@ -1,0 +1,208 @@
+import { WorkflowDefinitionError } from './errors';
+
+/**
+ * Input describing a discrete step within a workflow definition.
+ */
+export interface WorkflowStepInput {
+  /** Unique identifier for the step. */
+  readonly id: string;
+  /** Human-friendly name used in portals and audit logs. */
+  readonly name: string;
+  /** Narrative description documenting operational intent. */
+  readonly description: string;
+  /** Logical stage grouping (e.g. intake, verification, decision). */
+  readonly stage: string;
+  /**
+   * Upstream step identifiers that must be completed before this step becomes
+   * eligible for activation.
+   */
+  readonly dependencies: readonly string[];
+  /**
+   * Identifier of the next step to activate when this step succeeds. When
+   * `null`, the workflow is considered complete on success.
+   */
+  readonly onSuccess: string | null;
+  /**
+   * Optional identifier of the step to activate when this step fails. When
+   * omitted or `null`, the workflow will look for the next available step based
+   * on dependency satisfaction.
+   */
+  readonly onFailure?: string | null;
+  /** Target SLA duration for this step expressed in seconds. */
+  readonly expectedDurationSeconds?: number;
+  /** Arbitrary metadata for analytics, audit tags, etc. */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Input payload for creating a workflow definition.
+ */
+export interface WorkflowDefinitionInput {
+  /** Canonical identifier for the workflow (e.g. loan-orchestration). */
+  readonly id: string;
+  /** Human friendly name displayed in UIs and documentation. */
+  readonly name: string;
+  /** Semantic version or git SHA describing the workflow revision. */
+  readonly version: string;
+  /** Identifier for the entry step where the workflow begins. */
+  readonly entryStepId: string;
+  /** Ordered collection of steps to register with the workflow. */
+  readonly steps: readonly WorkflowStepInput[];
+  /** Optional metadata propagated to clients. */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Enriched workflow definition returned by {@link createWorkflowDefinition}.
+ */
+export interface WorkflowDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly version: string;
+  readonly entryStepId: string;
+  readonly steps: Record<string, WorkflowStepDefinition>;
+  readonly orderedStepIds: readonly string[];
+  readonly totalExpectedDurationSeconds: number;
+  readonly stageNames: readonly string[];
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Resolved step definition containing normalized structures for runtime use.
+ */
+export interface WorkflowStepDefinition extends WorkflowStepInput {
+  /** Index within {@link WorkflowDefinition.orderedStepIds}. */
+  readonly order: number;
+}
+
+/**
+ * Perform a topological sort of the workflow steps to guarantee deterministic
+ * ordering and to detect cycles early in the development process.
+ */
+const orderSteps = (
+  steps: readonly WorkflowStepInput[],
+): readonly string[] => {
+  const inDegree = new Map<string, number>();
+  const adjacency = new Map<string, Set<string>>();
+
+  for (const step of steps) {
+    if (!inDegree.has(step.id)) {
+      inDegree.set(step.id, 0);
+    }
+
+    for (const dependency of step.dependencies) {
+      const neighbors = adjacency.get(dependency) ?? new Set<string>();
+      neighbors.add(step.id);
+      adjacency.set(dependency, neighbors);
+      inDegree.set(step.id, (inDegree.get(step.id) ?? 0) + 1);
+      if (!inDegree.has(dependency)) {
+        inDegree.set(dependency, 0);
+      }
+    }
+  }
+
+  const queue: string[] = [];
+  for (const [stepId, degree] of inDegree) {
+    if (degree === 0) {
+      queue.push(stepId);
+    }
+  }
+
+  const ordered: string[] = [];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    ordered.push(id);
+
+    for (const neighbor of adjacency.get(id) ?? []) {
+      const nextDegree = (inDegree.get(neighbor) ?? 0) - 1;
+      inDegree.set(neighbor, nextDegree);
+      if (nextDegree === 0) {
+        queue.push(neighbor);
+      }
+    }
+  }
+
+  if (ordered.length !== inDegree.size) {
+    throw new WorkflowDefinitionError(
+      'Workflow definition contains a circular dependency. Review step dependency graph.',
+    );
+  }
+
+  return ordered;
+};
+
+/**
+ * Create an immutable workflow definition with validation and helpful
+ * denormalized views (ordered IDs, duration totals, etc.).
+ */
+export const createWorkflowDefinition = (
+  input: WorkflowDefinitionInput,
+): WorkflowDefinition => {
+  if (input.steps.length === 0) {
+    throw new WorkflowDefinitionError('Workflow definition must contain at least one step.');
+  }
+
+  const stepIds = new Set<string>();
+  for (const step of input.steps) {
+    if (stepIds.has(step.id)) {
+      throw new WorkflowDefinitionError(`Duplicate step identifier detected: ${step.id}`);
+    }
+    stepIds.add(step.id);
+  }
+
+  if (!stepIds.has(input.entryStepId)) {
+    throw new WorkflowDefinitionError(
+      `Entry step "${input.entryStepId}" does not exist in the provided steps array.`,
+    );
+  }
+
+  for (const step of input.steps) {
+    for (const dependency of step.dependencies) {
+      if (!stepIds.has(dependency)) {
+        throw new WorkflowDefinitionError(
+          `Step "${step.id}" declares missing dependency "${dependency}".`,
+        );
+      }
+    }
+
+    if (step.onSuccess && !stepIds.has(step.onSuccess)) {
+      throw new WorkflowDefinitionError(
+        `Step "${step.id}" references unknown success transition "${step.onSuccess}".`,
+      );
+    }
+
+    if (step.onFailure && !stepIds.has(step.onFailure)) {
+      throw new WorkflowDefinitionError(
+        `Step "${step.id}" references unknown failure transition "${step.onFailure}".`,
+      );
+    }
+  }
+
+  const orderedStepIds = orderSteps(input.steps);
+  const stageNames = Array.from(new Set(input.steps.map((step) => step.stage)));
+  const steps: Record<string, WorkflowStepDefinition> = {};
+  let totalExpectedDurationSeconds = 0;
+
+  orderedStepIds.forEach((stepId, order) => {
+    const step = input.steps.find((candidate) => candidate.id === stepId)!;
+    const expectedDurationSeconds = step.expectedDurationSeconds ?? 0;
+    totalExpectedDurationSeconds += expectedDurationSeconds;
+    steps[step.id] = {
+      ...step,
+      expectedDurationSeconds,
+      order,
+    };
+  });
+
+  return {
+    id: input.id,
+    name: input.name,
+    version: input.version,
+    entryStepId: input.entryStepId,
+    orderedStepIds,
+    steps,
+    totalExpectedDurationSeconds,
+    stageNames,
+    metadata: input.metadata,
+  };
+};

--- a/libs/core-domain/src/workflow-state.ts
+++ b/libs/core-domain/src/workflow-state.ts
@@ -1,0 +1,94 @@
+import type { WorkflowDefinition } from './workflow-definition';
+
+/**
+ * Contextual identifiers that allow orchestration services to correlate runtime
+ * state back to upstream systems such as the portal, underwriting engines, or
+ * audit logs.
+ */
+export interface WorkflowContext {
+  /** Tenant identifier that scoping multi-tenant data segregation. */
+  readonly tenantId: string;
+  /** Application identifier or business key representing the orchestration target. */
+  readonly applicationId: string;
+  /** Request-scoped correlation identifier to join telemetry and logs. */
+  readonly correlationId: string;
+  /** Optional metadata bag for arbitrary attributes (segment, campaign, etc.). */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Event emitted as the workflow transitions between states.
+ */
+export type WorkflowEvent =
+  | {
+      readonly type: 'WORKFLOW_INITIALIZED';
+      readonly occurredAt: Date;
+      readonly stepId: string;
+    }
+  | {
+      readonly type: 'STEP_ACTIVATED';
+      readonly stepId: string;
+      readonly occurredAt: Date;
+      readonly reason: 'initial-entry' | 'dependency-satisfied' | 'manual-retry';
+    }
+  | {
+      readonly type: 'STEP_COMPLETED';
+      readonly stepId: string;
+      readonly occurredAt: Date;
+      readonly notes?: string;
+    }
+  | {
+      readonly type: 'STEP_FAILED';
+      readonly stepId: string;
+      readonly occurredAt: Date;
+      readonly reason?: string;
+      readonly retryable?: boolean;
+    };
+
+/**
+ * Runtime representation of a workflow for a specific application instance.
+ */
+export interface WorkflowState {
+  readonly definitionId: string;
+  readonly definitionVersion: string;
+  readonly context: WorkflowContext;
+  readonly activeStepId: string | null;
+  readonly completedStepIds: readonly string[];
+  readonly failedStepIds: readonly string[];
+  readonly history: readonly WorkflowEvent[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options bag for {@link initializeWorkflow} allowing test harnesses to
+ * override timestamp behaviour.
+ */
+export interface InitializeWorkflowOptions {
+  /** Explicit timestamp for deterministic testing. Defaults to {@link Date.now}. */
+  readonly timestamp?: Date;
+  /** Additional metadata stored on the runtime state. */
+  readonly metadata?: Record<string, unknown>;
+}
+
+/**
+ * Internal helper to derive a workflow state skeleton that callers can extend.
+ */
+export const createEmptyState = (
+  definition: WorkflowDefinition,
+  context: WorkflowContext,
+  timestamp: Date,
+  metadata?: Record<string, unknown>,
+): WorkflowState => ({
+  definitionId: definition.id,
+  definitionVersion: definition.version,
+  context,
+  activeStepId: null,
+  completedStepIds: [],
+  failedStepIds: [],
+  history: [],
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  metadata,
+});

--- a/libs/core-domain/tsconfig.json
+++ b/libs/core-domain/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/core-domain/tsconfig.lib.json
+++ b/libs/core-domain/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/libs/core-domain/tsconfig.spec.json
+++ b/libs/core-domain/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "moduleResolution": "node10",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/nx.json
+++ b/nx.json
@@ -33,6 +33,11 @@
       "tags": ["type:lib", "scope:platform"],
       "implicitDependencies": []
     },
+    "core-domain": {
+      "root": "libs/core-domain",
+      "tags": ["type:lib", "scope:domain"],
+      "implicitDependencies": []
+    },
     "portal-web": {
       "root": "apps/portal-web",
       "tags": ["type:web", "scope:portal"],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "@asyncapi/generator": "^1.17.25",
     "@asyncapi/html-template": "^0.28.2",
     "@asyncapi/react-component": "^2.6.4",
+    "@nx/jest": "21.6.3",
+    "@nx/js": "21.6.3",
     "@nx/nest": "^21.6.3",
     "@nx/next": "^21.6.3",
     "@nx/playwright": "^21.6.3",
@@ -40,6 +42,7 @@
     "pdfkit": "^0.13.0",
     "puppeteer": "^21.11.0",
     "ts-jest": "^29.1.1",
+    "tslib": "^2.3.0",
     "typescript": "^5.4.2",
     "yaml": "^2.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,12 @@ importers:
       '@asyncapi/react-component':
         specifier: ^2.6.4
         version: 2.6.4(encoding@0.1.13)(postcss@8.4.49)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nx/jest':
+        specifier: 21.6.3
+        version: 21.6.3(@babel/traverse@7.28.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.19.129)(babel-plugin-macros@3.1.0)(nx@21.6.3(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.19.129)(typescript@5.9.3))(typescript@5.9.3)
+      '@nx/js':
+        specifier: 21.6.3
+        version: 21.6.3(@babel/traverse@7.28.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(nx@21.6.3(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))
       '@nx/nest':
         specifier: ^21.6.3
         version: 21.6.3(@babel/traverse@7.28.4)(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.19.129)(@zkochan/js-yaml@0.0.7)(babel-plugin-macros@3.1.0)(chokidar@3.6.0)(eslint@8.57.1)(nx@21.6.3(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.17)))(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.19.129)(typescript@5.9.3))(typescript@5.9.3)
@@ -87,11 +93,20 @@ importers:
       ts-jest:
         specifier: ^29.1.1
         version: 29.4.4(@babel/core@7.28.4)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.4))(jest-util@30.2.0)(jest@29.7.0(@types/node@18.19.129)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.5.29(@swc/helpers@0.5.17))(@types/node@18.19.129)(typescript@5.9.3)))(typescript@5.9.3)
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
       typescript:
         specifier: ^5.4.2
         version: 5.9.3
       yaml:
         specifier: ^2.4.2
+        version: 2.8.1
+
+  libs/core-domain:
+    dependencies:
+      tslib:
+        specifier: ^2.3.0
         version: 2.8.1
 
   libs/observability:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,8 @@
       "@plutus/iam/*": ["services/iam-svc/src/*"],
       "@plutus/observability": ["libs/observability/src/index"],
       "@plutus/observability/*": ["libs/observability/src/*"],
+      "@plutus/core-domain": ["libs/core-domain/src/index"],
+      "@plutus/core-domain/*": ["libs/core-domain/src/*"],
       "@plutus/security": ["libs/security/src/index"],
       "@plutus/security/*": ["libs/security/src/*"]
     }


### PR DESCRIPTION
## Summary
- generate the @plutus/core-domain library and wire it into the Nx workspace
- implement workflow definition builders, state machine transitions, timeline helpers, and reusable fixtures with TSDoc annotations
- add Jest specs covering happy path, branching, and failure flows plus developer documentation

## Testing
- pnpm nx build core-domain --output-style=stream
- pnpm nx test core-domain --output-style=stream

------
https://chatgpt.com/codex/tasks/task_e_68e064803678832e833c9e6858cc1e0c